### PR TITLE
Add custom height script prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ HTMLStyles | CSS style to be injected | `string` |
 defaultHeight | Webview's height before it's updated | `number` | 100
 additionalHeight | Add some height to the webview once it's calculated | `number` | 0
 bodyClass | Add some height to the webview once it's calculated | `string` | `''`
+customHeightScript | Override the default height script (for example if you wanted to make the height smaller)
 
 ## Tips and tricks
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ interface ComponentProps extends React.Props<DisplayHTML, {}> {
     defaultHeight?: number;
     additionalHeight?: number;
     bodyClass?: string;
+    customHeightScript?: Function;
 }
 
 export class DisplayHTML extends React.Component<ComponentProps, {}> {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,28 @@ import { View, WebView, Platform, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 import WebViewBridge from 'react-native-webview-bridge';
 
+/**
+ * Checks regularly the height of the webview to update the webview
+ * accordingly.
+ * Note : this isn't transpiled and must be written in ES5 !
+ */
+function heightScript () {
+    function updateHeight () {
+        var B = document.body;
+        var height;
+        if (typeof document.height !== 'undefined') {
+            height = document.height;
+        } else {
+            height = Math.max(B.scrollHeight, B.offsetHeight);
+        }
+        window.WebViewBridge.send(JSON.stringify({ height: height }));
+    }
+    if (window.WebViewBridge) {
+        updateHeight();
+        setInterval(updateHeight, 1000);
+    }
+}
+
 export default class DisplayHTML extends Component {
 
     static propTypes () {
@@ -16,7 +38,8 @@ export default class DisplayHTML extends Component {
             HTMLStyles: PropTypes.string,
             defaultHeight: PropTypes.number,
             additionalHeight: PropTypes.number,
-            bodyClass: PropTypes.string
+            bodyClass: PropTypes.string,
+            customHeightScript: PropTypes.func
         };
     };
 
@@ -27,7 +50,8 @@ export default class DisplayHTML extends Component {
         additionalHeight: 0,
         containerStyle: {},
         style: {},
-        bodyClass: ''
+        bodyClass: '',
+        customHeightScript: heightScript
     };
 
     constructor (props) {
@@ -36,7 +60,7 @@ export default class DisplayHTML extends Component {
             height: props.defaultHeight + props.additionalHeight
         };
         this.onMessage = this.onMessage.bind(this);
-        this.additionalScripts = [this.heightScript];
+        this.additionalScripts = [this.props.customHeightScript];
         if (props.additionalScripts && props.additionalScripts.length) {
             this.additionalScripts = this.additionalScripts.concat(props.additionalScripts);
         }
@@ -72,28 +96,6 @@ export default class DisplayHTML extends Component {
         }
 
         return source;
-    }
-
-    /**
-     * Checks regularly the height of the webview to update the webview
-     * accordingly.
-     * Note : this isn't transpiled and must be written in ES5 !
-     */
-    heightScript () {
-        function updateHeight () {
-            var B = document.body;
-            var height;
-            if (typeof document.height !== 'undefined') {
-                height = document.height;
-            } else {
-                height = Math.max(B.scrollHeight, B.offsetHeight);
-            }
-            window.WebViewBridge.send(JSON.stringify({ height: height }));
-        }
-        if (window.WebViewBridge) {
-            updateHeight();
-            setInterval(updateHeight, 1000);
-        }
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "ISC",
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react-native-webview-bridge": "git://github.com/archriss/react-native-webview-bridge.git#4f846f6"
+    "react-native-webview-bridge": "git+ssh://git@github.com:alinz/react-native-webview-bridge.git"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Adds a customHeightScript prop so that the script to determine the height can be customized. It is not currently possible to make the default height smaller, this would allow for that possibility.

An alternative solution would be to just change the default heightScript to use Math.min, but a custom function definitely allows for more flexibility.