### PR TITLE
Fix Typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,6 @@ interface ComponentProps extends React.Props<DisplayHTML, {}> {
     bodyClass?: string;
 }
 
-export class DisplayHTML extends React.Component<ComponentProps, {}> {
+export default class DisplayHTML extends React.Component<ComponentProps, {}> {
 
 }


### PR DESCRIPTION
Fixes the Typescript definition to declare the component class as the default export, as in the javascript implementation file.